### PR TITLE
Set Testmode default to True

### DIFF
--- a/Intune-Set-PrimaryUsers.ps1
+++ b/Intune-Set-PrimaryUsers.ps1
@@ -109,8 +109,8 @@ param(
     [ValidateRange(1,10)]
     [int]$MaxRetry                  = 3,
 
-    [Parameter(Mandatory = $false,          HelpMessage = "Testmode, same as -WhatIf. Default is true")]
-        [bool]$Testmode             = $false
+    [Parameter(Mandatory = $false,          HelpMessage = "Testmode or `$ExecutionMode, same as -WhatIf. Default is true")]
+        [bool]$Testmode             = $true
     )
 #endregion
 
@@ -1299,4 +1299,5 @@ finally {
     $MemoryUsage = [Math]::Round(([System.GC]::GetTotalMemory($false) / 1MB), 2)
     Write-Verbose "$($script:GetTimestamp.Invoke()),Info,$($MyInvocation.MyCommand.Name),Script finished. Memory usage: $MemoryUsage MB"
 }
+
 #endregion


### PR DESCRIPTION
The blogpost [Set Intune Primary User with Azure Automation](https://www.tbone.se/2025/03/31/set-intune-primary-user-with-azure-automation/) states that $ExecutionMode is set to "Test" or "Prod".  

> 17. Open your RunBook
> 18. Click Edit
> 19. Chage the setting **$ExecutionMode = “Test”** to run in Test mode and no real changes are made
> 20. Now you can click Test Pane
> 21. And run the script to see the results.
> 22. If it works as expected, change back **$ExecutionMode = “Prod”**

I presumed that you replaced this string param `$ExecutionMode` with the bool param `$Testmode`. I updated the HelpMessage and added a hint to the old param name and escaped it. That parameter defaulted to $false. I updated the default value to $true as stated in the HelpMessage.

Please review. Thanks, Markus