### PR TITLE
Fix: Fix false positive when assigning primary user without an Intune…

### DIFF
--- a/Set-IntunePrimaryUsers.ps1
+++ b/Set-IntunePrimaryUsers.ps1
@@ -838,7 +838,7 @@ function Invoke-MgGraphRequestSingle {
                             }
                             if ($ErrorMessage -match "does not have intune license or is deleted" -or $FullErrorString -match "does not have intune license or is deleted") { # Check if no license, common for Intune queries
                                 Write-Warning "Object Deleted or User has no Intune license"
-                                return "$ErrorMessage (Object Deleted/No User License)"
+                                throw "$ErrorMessage (Object Deleted/No User License)"
                             }
                             # For DELETE operations, "not found" patterns mean already removed - treat as success
                             if ($GraphMethod -eq 'DELETE' -and ($ErrorMessage -imatch 'does not exist|not found|cannot be found|no longer exists|was not found|resource .+ not found' -or $FullErrorString -imatch 'does not exist|not found|cannot be found|no longer exists')) {


### PR DESCRIPTION
**The Problem**
During script execution, when attempting to assign a user as primary owner who does not have an active Intune license (or has been recently deleted), the Microsoft Graph API returns an expected error.

However, inside the Invoke-MgGraphRequestSingle exception handling logic, this specific case was being caught and handled using a return "[error message]" statement instead of a throw. In PowerShell, returning a string does not interrupt the execution flow, causing the main calling block to interpret this string return as a successful response object. As a result, the script incorrectly logged a "Success-Updated" action in the report for these failed operations.

**Changes Introduced**
Modified the exception handling block inside Invoke-MgGraphRequestSingle for the 400 / BadRequest HTTP status code.

Replaced the return statement with a proper throw when the error string matches the "does not have intune license or is deleted" pattern.

**Expected Result**
From now on, whenever the API fails due to an invalid or unlicensed user, the function will correctly propagate the exception. The script's main loop will then capture the error inside its own catch block, accurately marking the affected device as "Failed" with the actual error details in the final report generated by Invoke-ScriptReport.